### PR TITLE
Team Tags Feature

### DIFF
--- a/src/main/java/teambuilder/logic/commands/EditCommand.java
+++ b/src/main/java/teambuilder/logic/commands/EditCommand.java
@@ -7,6 +7,7 @@ import static teambuilder.logic.parser.CliSyntax.PREFIX_MAJOR;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_NAME;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_PHONE;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_TAG;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_TEAM;
 import static teambuilder.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
@@ -47,7 +48,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_MAJOR + "MAJOR] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]"
+            + "[" + PREFIX_TEAM + "TEAM]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
@@ -110,8 +112,10 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Major updatedMajor = editPersonDescriptor.getMajor().orElse(personToEdit.getMajor());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        Set<Tag> updatedTeams = editPersonDescriptor.getTeams().orElse(personToEdit.getTeams());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedMajor, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedMajor,
+                updatedTags, updatedTeams);
     }
 
     @Override
@@ -142,6 +146,7 @@ public class EditCommand extends Command {
         private Address address;
         private Major major;
         private Set<Tag> tags;
+        private Set<Tag> teams;
 
         public EditPersonDescriptor() {
         }
@@ -156,6 +161,7 @@ public class EditCommand extends Command {
             setAddress(toCopy.address);
             setMajor(toCopy.major);
             setTags(toCopy.tags);
+            setTeams(toCopy.teams);
         }
 
         /**
@@ -210,6 +216,21 @@ public class EditCommand extends Command {
          */
         public void setTags(Set<Tag> tags) {
             this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        }
+
+        /**
+         * Sets {@code teams} to this object's {@code teams}. A defensive copy of {@code teams} is used internally.
+         */
+        public void setTeams(Set<Tag> teams) {
+            this.teams = (teams != null) ? new HashSet<>(teams) : null;
+        }
+
+        /**
+         * Returns an unmodifiable team tag set, which throws {@code UnsupportedOperationException} if modification is
+         * attempted. Returns {@code Optional#empty()} if {@code teams} is null.
+         */
+        public Optional<Set<Tag>> getTeams() {
+            return (teams != null) ? Optional.of(Collections.unmodifiableSet(teams)) : Optional.empty();
         }
 
         /**

--- a/src/main/java/teambuilder/logic/parser/AddCommandParser.java
+++ b/src/main/java/teambuilder/logic/parser/AddCommandParser.java
@@ -7,6 +7,7 @@ import static teambuilder.logic.parser.CliSyntax.PREFIX_MAJOR;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_NAME;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_PHONE;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_TAG;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_TEAM;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -47,8 +48,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Major major = ParserUtil.parseMajor(argMultimap.getValue(PREFIX_MAJOR).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        Set<Tag> teamList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TEAM));
 
-        Person person = new Person(name, phone, email, address, major, tagList);
+        Person person = new Person(name, phone, email, address, major, tagList, teamList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/teambuilder/logic/parser/CliSyntax.java
+++ b/src/main/java/teambuilder/logic/parser/CliSyntax.java
@@ -12,5 +12,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_MAJOR = new Prefix("m/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_TEAM = new Prefix("T/");
 
 }

--- a/src/main/java/teambuilder/model/person/Person.java
+++ b/src/main/java/teambuilder/model/person/Person.java
@@ -24,18 +24,21 @@ public class Person {
     private final Address address;
     private final Major major;
     private final Set<Tag> tags = new HashSet<>();
+    private final Set<Tag> teams = new HashSet<>();
 
     /**
-     * Every field must be present and not null.
+     * Every field must be present and not null. A person can however have no tags within their team tags.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Major major, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, major, tags);
+    public Person(Name name, Phone phone, Email email, Address address, Major major,
+                  Set<Tag> tags, Set<Tag> teams) {
+        requireAllNonNull(name, phone, email, address, major, tags, teams);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.major = major;
         this.tags.addAll(tags);
+        this.teams.addAll(teams);
     }
 
     public Name getName() {
@@ -64,6 +67,14 @@ public class Person {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    /**
+     * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<Tag> getTeams() {
+        return Collections.unmodifiableSet(teams);
     }
 
     /**
@@ -106,13 +117,14 @@ public class Person {
                 && otherPerson.getEmail().equals(getEmail())
                 && otherPerson.getAddress().equals(getAddress())
                 && otherPerson.getMajor().equals(getMajor())
-                && otherPerson.getTags().equals(getTags());
+                && otherPerson.getTags().equals(getTags())
+                && otherPerson.getTeams().equals((getTeams()));
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, major, tags);
+        return Objects.hash(name, phone, email, address, major, tags, teams);
     }
 
     @Override
@@ -131,6 +143,12 @@ public class Person {
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {
             builder.append("; Tags: ");
+            tags.forEach(builder::append);
+        }
+
+        Set<Tag> teams = getTeams();
+        if (!teams.isEmpty()) {
+            builder.append("; Teams: ");
             tags.forEach(builder::append);
         }
         return builder.toString();

--- a/src/main/java/teambuilder/model/tag/Tag.java
+++ b/src/main/java/teambuilder/model/tag/Tag.java
@@ -9,8 +9,9 @@ import static teambuilder.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric,"
+            + " with only a single whitespace between words if there are multiple words";
+    public static final String VALIDATION_REGEX = "^([a-zA-Z0-9]+\\s)*[a-zA-Z0-9]+$";
 
     public final String tagName;
 

--- a/src/main/java/teambuilder/model/util/SampleDataUtil.java
+++ b/src/main/java/teambuilder/model/util/SampleDataUtil.java
@@ -22,22 +22,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), new Major("Computer Science"),
-                getTagSet("friends")),
+                getTagSet("friends"), getTagSet("Team A")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Major("Computer Science"),
-                getTagSet("colleagues", "friends")),
+                getTagSet("colleagues", "friends"), getTagSet("Team A", "CS2103T G17")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Major("Computer Science"),
-                getTagSet("neighbours")),
+                getTagSet("neighbours"), getTagSet("Rh Rockers")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Major("Computer Science"),
-                getTagSet("family")),
+                getTagSet("family"), getTagSet("Club penguin")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), new Major("Computer Science"),
-                getTagSet("classmates")),
+                getTagSet("classmates"), getTagSet("RuneScapers")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), new Major("Computer Science"),
-                getTagSet("colleagues"))
+                getTagSet("colleagues"), getTagSet("Coding is fun club"))
         };
     }
 

--- a/src/main/java/teambuilder/storage/JsonAdaptedPerson.java
+++ b/src/main/java/teambuilder/storage/JsonAdaptedPerson.java
@@ -31,6 +31,7 @@ class JsonAdaptedPerson {
     private final String address;
     private final String major;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+    private final List<JsonAdaptedTag> teams = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -38,7 +39,8 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("major") String major, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+            @JsonProperty("major") String major, @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
+            @JsonProperty("teams") List<JsonAdaptedTag> teams) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -46,6 +48,9 @@ class JsonAdaptedPerson {
         this.major = major;
         if (tagged != null) {
             this.tagged.addAll(tagged);
+        }
+        if (teams != null) {
+            this.teams.addAll(teams);
         }
     }
 
@@ -61,6 +66,9 @@ class JsonAdaptedPerson {
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        teams.addAll(source.getTeams().stream()
+                .map(JsonAdaptedTag::new)
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -72,6 +80,10 @@ class JsonAdaptedPerson {
         final List<Tag> personTags = new ArrayList<>();
         for (JsonAdaptedTag tag : tagged) {
             personTags.add(tag.toModelType());
+        }
+        final List<Tag> personTeams = new ArrayList<>();
+        for (JsonAdaptedTag tag : teams) {
+            personTeams.add(tag.toModelType());
         }
 
         if (name == null) {
@@ -115,7 +127,10 @@ class JsonAdaptedPerson {
         final Major modelMajor = new Major(major);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelMajor, modelTags);
+
+        final Set<Tag> modelTeams = new HashSet<>(personTeams);
+
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelMajor, modelTags, modelTeams);
     }
 
 }

--- a/src/main/java/teambuilder/ui/PersonCard.java
+++ b/src/main/java/teambuilder/ui/PersonCard.java
@@ -42,6 +42,8 @@ public class PersonCard extends UiPart<Region> {
     private Label major;
     @FXML
     private FlowPane tags;
+    @FXML
+    private FlowPane teams;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -58,6 +60,9 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        person.getTeams().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .forEach(tag -> teams.getChildren().add(new Label(tag.tagName)));
     }
 
     @Override

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -350,3 +350,17 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+
+#teams {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#teams .label {
+    -fx-text-fill: white;
+    -fx-background-color: #FF5964;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -29,6 +29,7 @@
         <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
       </HBox>
       <FlowPane fx:id="tags" />
+      <FlowPane fx:id="teams" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />

--- a/src/test/java/teambuilder/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/teambuilder/storage/JsonAdaptedPersonTest.java
@@ -42,7 +42,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_MAJOR, VALID_TAGS);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_MAJOR,
+                        VALID_TAGS, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -50,7 +51,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_MAJOR, VALID_TAGS);
+                new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_MAJOR,
+                        VALID_TAGS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -58,7 +60,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_MAJOR, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_MAJOR,
+                        VALID_TAGS, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -66,7 +69,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_MAJOR, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_MAJOR,
+                        VALID_TAGS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -74,7 +78,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_MAJOR, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_MAJOR,
+                        VALID_TAGS, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -82,7 +87,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_MAJOR, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_MAJOR,
+                        VALID_TAGS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -90,7 +96,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_MAJOR, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_MAJOR,
+                        VALID_TAGS, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -98,7 +105,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_MAJOR, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_MAJOR,
+                        VALID_TAGS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -108,7 +116,8 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_MAJOR, invalidTags);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_MAJOR,
+                        invalidTags, VALID_TAGS);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/teambuilder/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/teambuilder/testutil/EditPersonDescriptorBuilder.java
@@ -39,6 +39,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setAddress(person.getAddress());
         descriptor.setMajor(person.getMajor());
         descriptor.setTags(person.getTags());
+        descriptor.setTeams(person.getTeams());
     }
 
     /**
@@ -90,6 +91,8 @@ public class EditPersonDescriptorBuilder {
         descriptor.setTags(tagSet);
         return this;
     }
+
+    //TODO: withTeams test
 
     public EditPersonDescriptor build() {
         return descriptor;

--- a/src/test/java/teambuilder/testutil/PersonBuilder.java
+++ b/src/test/java/teambuilder/testutil/PersonBuilder.java
@@ -29,6 +29,8 @@ public class PersonBuilder {
     private Address address;
     private Major major;
     private Set<Tag> tags;
+    private Set<Tag> teams;
+
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -40,6 +42,7 @@ public class PersonBuilder {
         address = new Address(DEFAULT_ADDRESS);
         major = new Major(DEFAULT_MAJOR);
         tags = new HashSet<>();
+        teams = new HashSet<>();
     }
 
     /**
@@ -52,6 +55,7 @@ public class PersonBuilder {
         address = personToCopy.getAddress();
         major = personToCopy.getMajor();
         tags = new HashSet<>(personToCopy.getTags());
+        teams = new HashSet<>(personToCopy.getTeams());
     }
 
     /**
@@ -67,6 +71,14 @@ public class PersonBuilder {
      */
     public PersonBuilder withTags(String ... tags) {
         this.tags = SampleDataUtil.getTagSet(tags);
+        return this;
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
+     */
+    public PersonBuilder withTeams(String ... tags) {
+        this.teams = SampleDataUtil.getTagSet(tags);
         return this;
     }
 
@@ -103,7 +115,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, address, major, tags);
+        return new Person(name, phone, email, address, major, tags, teams);
     }
 
 }


### PR DESCRIPTION

As a user, I can now add team tags to a person such that I know which teams they are in.

Users can now tag persons in their contact list with team tags, which are shown and stored separately from normal tags.
