### PR TITLE
Modify the edit command and parser for teamTags

### DIFF
--- a/src/main/java/teambuilder/logic/commands/EditCommand.java
+++ b/src/main/java/teambuilder/logic/commands/EditCommand.java
@@ -168,7 +168,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, major, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, major, tags, teams);
         }
 
         public void setName(Name name) {
@@ -262,7 +262,8 @@ public class EditCommand extends Command {
                     && getEmail().equals(e.getEmail())
                     && getAddress().equals(e.getAddress())
                     && getMajor().equals(e.getMajor())
-                    && getTags().equals(e.getTags());
+                    && getTags().equals(e.getTags())
+                    && getTeams().equals(e.getTeams());
             // @formatter:on
         }
     }

--- a/src/main/java/teambuilder/logic/parser/EditCommandParser.java
+++ b/src/main/java/teambuilder/logic/parser/EditCommandParser.java
@@ -8,6 +8,7 @@ import static teambuilder.logic.parser.CliSyntax.PREFIX_MAJOR;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_NAME;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_PHONE;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_TAG;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_TEAM;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -34,7 +35,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                        PREFIX_ADDRESS, PREFIX_MAJOR, PREFIX_TAG);
+                        PREFIX_ADDRESS, PREFIX_MAJOR, PREFIX_TAG, PREFIX_TEAM);
 
         Index index;
 
@@ -61,6 +62,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setMajor(ParserUtil.parseMajor(argMultimap.getValue(PREFIX_MAJOR).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TEAM)).ifPresent(editPersonDescriptor::setTeams);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);


### PR DESCRIPTION
The previous change made for the edit command did not import the PREFIX_TEAM from CliSyntax in EditCommandParser, so edit command for TeamTags is not working