### PR TITLE
Modify the edit command and parser for teamTags

### DIFF
--- a/src/main/java/teambuilder/logic/commands/EditCommand.java
+++ b/src/main/java/teambuilder/logic/commands/EditCommand.java
@@ -219,6 +219,14 @@ public class EditCommand extends Command {
         }
 
         /**
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException} if modification is
+         * attempted. Returns {@code Optional#empty()} if {@code tags} is null.
+         */
+        public Optional<Set<Tag>> getTags() {
+            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        /**
          * Sets {@code teams} to this object's {@code teams}. A defensive copy of {@code teams} is used internally.
          */
         public void setTeams(Set<Tag> teams) {
@@ -231,14 +239,6 @@ public class EditCommand extends Command {
          */
         public Optional<Set<Tag>> getTeams() {
             return (teams != null) ? Optional.of(Collections.unmodifiableSet(teams)) : Optional.empty();
-        }
-
-        /**
-         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException} if modification is
-         * attempted. Returns {@code Optional#empty()} if {@code tags} is null.
-         */
-        public Optional<Set<Tag>> getTags() {
-            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
         @Override
@@ -262,8 +262,8 @@ public class EditCommand extends Command {
                     && getEmail().equals(e.getEmail())
                     && getAddress().equals(e.getAddress())
                     && getMajor().equals(e.getMajor())
-                    && getTags().equals(e.getTags())
-                    && getTeams().equals(e.getTeams());
+                    //&& getTeams().equals(e.getTeams())
+                    && getTags().equals(e.getTags());
             // @formatter:on
         }
     }

--- a/src/main/java/teambuilder/logic/commands/EditCommand.java
+++ b/src/main/java/teambuilder/logic/commands/EditCommand.java
@@ -168,7 +168,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, major, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, major, tags, teams);
         }
 
         public void setName(Name name) {
@@ -262,7 +262,8 @@ public class EditCommand extends Command {
                     && getEmail().equals(e.getEmail())
                     && getAddress().equals(e.getAddress())
                     && getMajor().equals(e.getMajor())
-                    && getTags().equals(e.getTags());
+                    && getTags().equals(e.getTags())
+                    && getTeams().equals(e.getTeams());
             // @formatter:on
         }
     }

--- a/src/main/java/teambuilder/logic/parser/EditCommandParser.java
+++ b/src/main/java/teambuilder/logic/parser/EditCommandParser.java
@@ -10,10 +10,7 @@ import static teambuilder.logic.parser.CliSyntax.PREFIX_PHONE;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_TAG;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_TEAM;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import teambuilder.commons.core.index.Index;
 import teambuilder.logic.commands.EditCommand;
@@ -62,6 +59,9 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setMajor(ParserUtil.parseMajor(argMultimap.getValue(PREFIX_MAJOR).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+//        if (argMultimap.getAllValues(PREFIX_TEAM).isEmpty()) {
+//            editPersonDescriptor.setTeams(new HashSet<>());
+//        }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TEAM)).ifPresent(editPersonDescriptor::setTeams);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/teambuilder/logic/parser/EditCommandParser.java
+++ b/src/main/java/teambuilder/logic/parser/EditCommandParser.java
@@ -8,6 +8,7 @@ import static teambuilder.logic.parser.CliSyntax.PREFIX_MAJOR;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_NAME;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_PHONE;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_TAG;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_TEAM;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -34,7 +35,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                        PREFIX_ADDRESS, PREFIX_MAJOR, PREFIX_TAG);
+                        PREFIX_ADDRESS, PREFIX_MAJOR, PREFIX_TAG, PREFIX_TEAM);
 
         Index index;
 
@@ -61,6 +62,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setMajor(ParserUtil.parseMajor(argMultimap.getValue(PREFIX_MAJOR).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TEAM)).ifPresent(editPersonDescriptor::setTeams);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/teambuilder/logic/parser/EditCommandParser.java
+++ b/src/main/java/teambuilder/logic/parser/EditCommandParser.java
@@ -10,7 +10,10 @@ import static teambuilder.logic.parser.CliSyntax.PREFIX_PHONE;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_TAG;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_TEAM;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import teambuilder.commons.core.index.Index;
 import teambuilder.logic.commands.EditCommand;
@@ -59,9 +62,9 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setMajor(ParserUtil.parseMajor(argMultimap.getValue(PREFIX_MAJOR).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
-//        if (argMultimap.getAllValues(PREFIX_TEAM).isEmpty()) {
-//            editPersonDescriptor.setTeams(new HashSet<>());
-//        }
+        //if (argMultimap.getAllValues(PREFIX_TEAM).isEmpty()) {
+        //    editPersonDescriptor.setTeams(new HashSet<>());
+        //}
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TEAM)).ifPresent(editPersonDescriptor::setTeams);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {

--- a/src/test/java/teambuilder/logic/LogicManagerTest.java
+++ b/src/test/java/teambuilder/logic/LogicManagerTest.java
@@ -82,7 +82,7 @@ public class LogicManagerTest {
         // Execute add command
         String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
                 + ADDRESS_DESC_AMY + MAJOR_DESC_AMY;
-        Person expectedPerson = new PersonBuilder(AMY).withTags().build();
+        Person expectedPerson = new PersonBuilder(AMY).withTags().withTeams().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;

--- a/src/test/java/teambuilder/logic/commands/CommandTestUtil.java
+++ b/src/test/java/teambuilder/logic/commands/CommandTestUtil.java
@@ -2,12 +2,7 @@ package teambuilder.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static teambuilder.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static teambuilder.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static teambuilder.logic.parser.CliSyntax.PREFIX_MAJOR;
-import static teambuilder.logic.parser.CliSyntax.PREFIX_NAME;
-import static teambuilder.logic.parser.CliSyntax.PREFIX_PHONE;
-import static teambuilder.logic.parser.CliSyntax.PREFIX_TAG;
+import static teambuilder.logic.parser.CliSyntax.*;
 import static teambuilder.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -39,6 +34,7 @@ public class CommandTestUtil {
     public static final String VALID_MAJOR_BOB = "Business";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_TAG_TEAM = "project";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -52,6 +48,7 @@ public class CommandTestUtil {
     public static final String MAJOR_DESC_BOB = " " + PREFIX_MAJOR + VALID_MAJOR_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String TAG_DESC_TEAM = " " + PREFIX_TEAM + VALID_TAG_TEAM;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
@@ -68,10 +65,11 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withMajor(VALID_MAJOR_AMY).withTags(VALID_TAG_FRIEND).build();
+                .withMajor(VALID_MAJOR_AMY).withTags(VALID_TAG_FRIEND).withTeams(VALID_TAG_TEAM).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-                .withMajor(VALID_MAJOR_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withMajor(VALID_MAJOR_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+                .withTeams(VALID_TAG_TEAM).build();
     }
 
     /**

--- a/src/test/java/teambuilder/logic/commands/CommandTestUtil.java
+++ b/src/test/java/teambuilder/logic/commands/CommandTestUtil.java
@@ -2,7 +2,13 @@ package teambuilder.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static teambuilder.logic.parser.CliSyntax.*;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_MAJOR;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_NAME;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_PHONE;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_TAG;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_TEAM;
 import static teambuilder.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;

--- a/src/test/java/teambuilder/logic/parser/TeamBuilderParserTest.java
+++ b/src/test/java/teambuilder/logic/parser/TeamBuilderParserTest.java
@@ -58,9 +58,10 @@ public class TeamBuilderParserTest {
     public void parseCommand_edit() throws Exception {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
+        EditCommand expected = new EditCommand(INDEX_FIRST_PERSON, descriptor);
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+        assertEquals(expected, command);
     }
 
     @Test

--- a/src/test/java/teambuilder/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/teambuilder/testutil/EditPersonDescriptorBuilder.java
@@ -92,6 +92,15 @@ public class EditPersonDescriptorBuilder {
         return this;
     }
 
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code EditPersonDescriptor}
+     * that we are building.
+     */
+    public EditPersonDescriptorBuilder withTeams(String... teams) {
+        Set<Tag> tagSet = Stream.of(teams).map(Tag::new).collect(Collectors.toSet());
+        descriptor.setTeams(tagSet);
+        return this;
+    }
     //TODO: withTeams test
 
     public EditPersonDescriptor build() {

--- a/src/test/java/teambuilder/testutil/PersonUtil.java
+++ b/src/test/java/teambuilder/testutil/PersonUtil.java
@@ -1,18 +1,19 @@
 package teambuilder.testutil;
 
-import static teambuilder.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static teambuilder.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static teambuilder.logic.parser.CliSyntax.PREFIX_MAJOR;
-import static teambuilder.logic.parser.CliSyntax.PREFIX_NAME;
-import static teambuilder.logic.parser.CliSyntax.PREFIX_PHONE;
-import static teambuilder.logic.parser.CliSyntax.PREFIX_TAG;
-
 import java.util.Set;
 
 import teambuilder.logic.commands.AddCommand;
 import teambuilder.logic.commands.EditCommand.EditPersonDescriptor;
 import teambuilder.model.person.Person;
 import teambuilder.model.tag.Tag;
+
+import static teambuilder.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_MAJOR;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_NAME;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_PHONE;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_TAG;
+import static teambuilder.logic.parser.CliSyntax.PREFIX_TEAM;
 
 /**
  * A utility class for Person.
@@ -39,6 +40,9 @@ public class PersonUtil {
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
+        person.getTeams().stream().forEach(
+                s -> sb.append(PREFIX_TEAM + s.tagName + " ")
+        );
         return sb.toString();
     }
 
@@ -58,6 +62,12 @@ public class PersonUtil {
                 sb.append(PREFIX_TAG);
             } else {
                 tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
+            }
+        }
+        if (descriptor.getTeams().isPresent()) {
+            Set<Tag> teams = descriptor.getTeams().get();
+            if (!teams.isEmpty()) {
+                teams.forEach(s -> sb.append(PREFIX_TEAM).append(s.tagName).append(" "));
             }
         }
         return sb.toString();

--- a/src/test/java/teambuilder/testutil/PersonUtil.java
+++ b/src/test/java/teambuilder/testutil/PersonUtil.java
@@ -1,12 +1,5 @@
 package teambuilder.testutil;
 
-import java.util.Set;
-
-import teambuilder.logic.commands.AddCommand;
-import teambuilder.logic.commands.EditCommand.EditPersonDescriptor;
-import teambuilder.model.person.Person;
-import teambuilder.model.tag.Tag;
-
 import static teambuilder.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_MAJOR;
@@ -14,6 +7,13 @@ import static teambuilder.logic.parser.CliSyntax.PREFIX_NAME;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_PHONE;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_TAG;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_TEAM;
+
+import java.util.Set;
+
+import teambuilder.logic.commands.AddCommand;
+import teambuilder.logic.commands.EditCommand.EditPersonDescriptor;
+import teambuilder.model.person.Person;
+import teambuilder.model.tag.Tag;
 
 /**
  * A utility class for Person.


### PR DESCRIPTION
Resolve #47 
The previous change made for the edit command did not import the PREFIX_TEAM from CliSyntax in EditCommandParser, so edit command for TeamTags is not working.