### PR TITLE
Teamlist and associated commands

### DIFF
--- a/src/main/java/teambuilder/commons/core/Messages.java
+++ b/src/main/java/teambuilder/commons/core/Messages.java
@@ -10,7 +10,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_INVALID_SORTING_ORDER = "Invalid sorting order, input \"desc\" or \"asc\"";
-
+    public static final String MESSAGE_INVALID_TEAM = "The team name provided is invalid";
     public static final String MESSAGE_INVALID_SORT_BY = "Invalid sort by";
 
 }

--- a/src/main/java/teambuilder/logic/commands/AddCommand.java
+++ b/src/main/java/teambuilder/logic/commands/AddCommand.java
@@ -8,6 +8,8 @@ import static teambuilder.logic.parser.CliSyntax.PREFIX_NAME;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_PHONE;
 import static teambuilder.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.List;
+
 import teambuilder.commons.core.Memento;
 import teambuilder.commons.util.HistoryUtil;
 import teambuilder.logic.commands.exceptions.CommandException;
@@ -15,8 +17,6 @@ import teambuilder.model.Model;
 import teambuilder.model.person.Person;
 import teambuilder.model.tag.Tag;
 import teambuilder.model.team.Team;
-
-import java.util.List;
 
 /**
  * Adds a person to the address book.

--- a/src/main/java/teambuilder/logic/commands/AddCommand.java
+++ b/src/main/java/teambuilder/logic/commands/AddCommand.java
@@ -13,6 +13,10 @@ import teambuilder.commons.util.HistoryUtil;
 import teambuilder.logic.commands.exceptions.CommandException;
 import teambuilder.model.Model;
 import teambuilder.model.person.Person;
+import teambuilder.model.tag.Tag;
+import teambuilder.model.team.Team;
+
+import java.util.List;
 
 /**
  * Adds a person to the address book.
@@ -41,6 +45,7 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_TEAM_NOT_FOUND = "The team does not exist in the address book";
 
     private final Person toAdd;
 
@@ -60,10 +65,28 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        // throw exception if team tags not from existing teams
+        List<Team> teamList = model.getTeamList();
+        Object[] teamTags = toAdd.getTeams().toArray();
+        for (Object tag : teamTags) {
+            Tag castedTag = (Tag) tag;
+            boolean isPresent = false;
+            for (Team team : teamList) {
+                if (castedTag.getName().equals(team.toString())) {
+                    isPresent = true;
+                    break;
+                }
+            }
+            if (!isPresent) {
+                throw new CommandException(MESSAGE_TEAM_NOT_FOUND);
+            }
+        }
+
         Memento old = model.save();
         HistoryUtil.getInstance().storePast(old, COMMAND_WORD + " " + toAdd);
 
         model.addPerson(toAdd);
+        model.updatePersonInTeams(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/teambuilder/logic/commands/CreateCommand.java
+++ b/src/main/java/teambuilder/logic/commands/CreateCommand.java
@@ -46,11 +46,11 @@ public class CreateCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        //        if (model.hasTeam(toCreate)) {
-        //            throw new CommandException(MESSAGE_DUPLICATE_TEAM);
-        //        }
-        //
-        //        model.addTeam(toCreate);
+        if (model.hasTeam(toCreate)) {
+            throw new CommandException(MESSAGE_DUPLICATE_TEAM);
+        }
+
+        model.addTeam(toCreate);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, toCreate));
     }

--- a/src/main/java/teambuilder/logic/commands/DeleteCommand.java
+++ b/src/main/java/teambuilder/logic/commands/DeleteCommand.java
@@ -45,6 +45,7 @@ public class DeleteCommand extends Command {
         Memento old = model.save();
         HistoryUtil.getInstance().storePast(old, COMMAND_WORD + " " + personToDelete);
 
+        model.removeFromAllTeams(personToDelete);
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }

--- a/src/main/java/teambuilder/logic/commands/RemoveCommand.java
+++ b/src/main/java/teambuilder/logic/commands/RemoveCommand.java
@@ -1,18 +1,16 @@
 package teambuilder.logic.commands;
 
-import teambuilder.commons.core.Memento;
-import teambuilder.commons.core.Messages;
-import teambuilder.commons.core.index.Index;
-import teambuilder.commons.util.HistoryUtil;
-import teambuilder.logic.commands.exceptions.CommandException;
-import teambuilder.model.Model;
-import teambuilder.model.person.Person;
-import teambuilder.model.team.Team;
-import teambuilder.model.team.TeamName;
+import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
-import static java.util.Objects.requireNonNull;
+import teambuilder.commons.core.Memento;
+import teambuilder.commons.core.Messages;
+import teambuilder.commons.util.HistoryUtil;
+import teambuilder.logic.commands.exceptions.CommandException;
+import teambuilder.model.Model;
+import teambuilder.model.team.Team;
+import teambuilder.model.team.TeamName;
 
 /**
  * Removes a team identified using its name from the address book.

--- a/src/main/java/teambuilder/logic/commands/RemoveCommand.java
+++ b/src/main/java/teambuilder/logic/commands/RemoveCommand.java
@@ -1,0 +1,65 @@
+package teambuilder.logic.commands;
+
+import teambuilder.commons.core.Memento;
+import teambuilder.commons.core.Messages;
+import teambuilder.commons.core.index.Index;
+import teambuilder.commons.util.HistoryUtil;
+import teambuilder.logic.commands.exceptions.CommandException;
+import teambuilder.model.Model;
+import teambuilder.model.person.Person;
+import teambuilder.model.team.Team;
+import teambuilder.model.team.TeamName;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Removes a team identified using its name from the address book.
+ */
+public class RemoveCommand extends Command {
+    public static final String COMMAND_WORD = "remove";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Removes the team identified by its name.\n"
+            + "Parameters: TEAMNAME \n" + "Example: " + COMMAND_WORD + " Team A";
+
+    public static final String MESSAGE_DELETE_TEAM_SUCCESS = "Removed Team: %1$s";
+
+    private final TeamName targetName;
+
+    public RemoveCommand(TeamName targetName) {
+        this.targetName = targetName;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Team> lastShownList = model.getTeamList();
+        Team teamToDelete = null;
+
+        for (Team team : lastShownList) {
+            if (team.getName().equals(targetName)) {
+                teamToDelete = team;
+                break;
+            }
+        }
+
+        if (teamToDelete == null) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TEAM);
+        }
+
+        Memento old = model.save();
+        HistoryUtil.getInstance().storePast(old, COMMAND_WORD + " " + teamToDelete);
+
+        model.deleteTeam(teamToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_TEAM_SUCCESS, teamToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RemoveCommand // instanceof handles nulls
+                && targetName.equals(((RemoveCommand) other).targetName)); // state check
+    }
+}

--- a/src/main/java/teambuilder/logic/parser/RemoveCommandParser.java
+++ b/src/main/java/teambuilder/logic/parser/RemoveCommandParser.java
@@ -2,7 +2,6 @@ package teambuilder.logic.parser;
 
 import static teambuilder.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import teambuilder.logic.commands.DeleteCommand;
 import teambuilder.logic.commands.RemoveCommand;
 import teambuilder.logic.parser.exceptions.ParseException;
 import teambuilder.model.team.TeamName;

--- a/src/main/java/teambuilder/logic/parser/RemoveCommandParser.java
+++ b/src/main/java/teambuilder/logic/parser/RemoveCommandParser.java
@@ -22,7 +22,7 @@ public class RemoveCommandParser {
             return new RemoveCommand(name);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/teambuilder/logic/parser/RemoveCommandParser.java
+++ b/src/main/java/teambuilder/logic/parser/RemoveCommandParser.java
@@ -1,0 +1,30 @@
+package teambuilder.logic.parser;
+
+import teambuilder.commons.core.index.Index;
+import teambuilder.logic.commands.DeleteCommand;
+import teambuilder.logic.commands.RemoveCommand;
+import teambuilder.logic.parser.exceptions.ParseException;
+import teambuilder.model.team.TeamName;
+
+import static teambuilder.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new RemoveCommand object
+ */
+public class RemoveCommandParser {
+    /**
+     * Parses the given {@code String} of arguments in the context of the RemoveCommand
+     * and returns a RemoveCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public RemoveCommand parse(String args) throws ParseException {
+        try {
+            TeamName name = ParserUtil.parseTeamName(args);
+            return new RemoveCommand(name);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/teambuilder/logic/parser/RemoveCommandParser.java
+++ b/src/main/java/teambuilder/logic/parser/RemoveCommandParser.java
@@ -1,12 +1,11 @@
 package teambuilder.logic.parser;
 
-import teambuilder.commons.core.index.Index;
+import static teambuilder.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import teambuilder.logic.commands.DeleteCommand;
 import teambuilder.logic.commands.RemoveCommand;
 import teambuilder.logic.parser.exceptions.ParseException;
 import teambuilder.model.team.TeamName;
-
-import static teambuilder.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 /**
  * Parses input arguments and creates a new RemoveCommand object

--- a/src/main/java/teambuilder/logic/parser/TeamBuilderParser.java
+++ b/src/main/java/teambuilder/logic/parser/TeamBuilderParser.java
@@ -17,6 +17,7 @@ import teambuilder.logic.commands.FindCommand;
 import teambuilder.logic.commands.HelpCommand;
 import teambuilder.logic.commands.ListCommand;
 import teambuilder.logic.commands.RedoCommand;
+import teambuilder.logic.commands.RemoveCommand;
 import teambuilder.logic.commands.SortCommand;
 import teambuilder.logic.commands.UndoCommand;
 import teambuilder.logic.parser.exceptions.ParseException;
@@ -82,6 +83,9 @@ public class TeamBuilderParser {
 
         case CreateCommand.COMMAND_WORD:
             return new CreateCommandParser().parse(arguments);
+
+        case RemoveCommand.COMMAND_WORD:
+            return new RemoveCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/teambuilder/model/Model.java
+++ b/src/main/java/teambuilder/model/Model.java
@@ -8,6 +8,7 @@ import javafx.collections.ObservableList;
 import teambuilder.commons.core.GuiSettings;
 import teambuilder.commons.core.Originator;
 import teambuilder.model.person.Person;
+import teambuilder.model.team.Team;
 
 /**
  * The API of the Model component.
@@ -78,8 +79,28 @@ public interface Model extends Originator {
      */
     void setPerson(Person target, Person editedPerson);
 
+    /**
+     * Returns true if a team with the same identity as {@code team} exists in the address book.
+     */
+    boolean hasTeam(Team team);
+
+    /**
+     * Deletes the given team.
+     * The team must exist in the address book.
+     */
+    void deleteTeam(Team target);
+
+    /**
+     * Adds the given team.
+     * {@code team} must not already exist in the address book.
+     */
+    void addTeam(Team team);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getSortedPersonList();
+
+    /** Returns an unmodifiable view of the team list */
+    ObservableList<Team> getTeamList();
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.

--- a/src/main/java/teambuilder/model/Model.java
+++ b/src/main/java/teambuilder/model/Model.java
@@ -96,6 +96,16 @@ public interface Model extends Originator {
      */
     void addTeam(Team team);
 
+    /**
+     * Adds person to the team, based on its team tags.
+     */
+    void updatePersonInTeams(Person person);
+
+    /**
+     * Removes person from all teams
+     */
+    void removeFromAllTeams(Person person);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getSortedPersonList();
 

--- a/src/main/java/teambuilder/model/ModelManager.java
+++ b/src/main/java/teambuilder/model/ModelManager.java
@@ -15,6 +15,7 @@ import teambuilder.commons.core.GuiSettings;
 import teambuilder.commons.core.LogsCenter;
 import teambuilder.commons.core.Memento;
 import teambuilder.model.person.Person;
+import teambuilder.model.team.Team;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -26,6 +27,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
     private final SortedList<Person> sortedPersons;
+    private final FilteredList<Team> filteredTeams;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -39,6 +41,7 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         sortedPersons = new SortedList<>(filteredPersons);
+        filteredTeams = new FilteredList<>(this.addressBook.getTeamList());
     }
 
     public ModelManager() {
@@ -119,6 +122,34 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+    }
+
+    @Override
+    public boolean hasTeam(Team team) {
+        requireNonNull(team);
+        return addressBook.hasTeam(team);
+    }
+
+    @Override
+    public void addTeam(Team team) {
+        addressBook.addTeam(team);
+        //updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+    }
+
+    @Override
+    public void deleteTeam(Team target) {
+        addressBook.removeTeam(target);
+    }
+
+    //=========== Filtered Team List Accessors ===============================================================
+
+    /**
+     * Returns an unmodifiable view of the list of {@code Team} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
+    @Override
+    public ObservableList<Team> getTeamList() {
+        return filteredTeams;
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/teambuilder/model/ModelManager.java
+++ b/src/main/java/teambuilder/model/ModelManager.java
@@ -141,6 +141,16 @@ public class ModelManager implements Model {
         addressBook.removeTeam(target);
     }
 
+    @Override
+    public void updatePersonInTeams(Person person) {
+        addressBook.updatePersonInTeams(person);
+    }
+
+    @Override
+    public void removeFromAllTeams(Person person) {
+        addressBook.removeFromAllTeams(person);
+    }
+
     //=========== Filtered Team List Accessors ===============================================================
 
     /**

--- a/src/main/java/teambuilder/model/ReadOnlyTeamBuilder.java
+++ b/src/main/java/teambuilder/model/ReadOnlyTeamBuilder.java
@@ -2,6 +2,7 @@ package teambuilder.model;
 
 import javafx.collections.ObservableList;
 import teambuilder.model.person.Person;
+import teambuilder.model.team.Team;
 
 /**
  * Unmodifiable view of an address book
@@ -13,5 +14,11 @@ public interface ReadOnlyTeamBuilder {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Person> getPersonList();
+
+    /**
+     * Returns an unmodifiable view of the teams list.
+     * This list will not contain any duplicate teams.
+     */
+    ObservableList<Team> getTeamList();
 
 }

--- a/src/main/java/teambuilder/model/TeamBuilder.java
+++ b/src/main/java/teambuilder/model/TeamBuilder.java
@@ -7,6 +7,8 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import teambuilder.model.person.Person;
 import teambuilder.model.person.UniquePersonList;
+import teambuilder.model.team.Team;
+import teambuilder.model.team.UniqueTeamList;
 
 /**
  * Wraps all data at the address-book level
@@ -25,6 +27,19 @@ public class TeamBuilder implements ReadOnlyTeamBuilder {
      */
     {
         persons = new UniquePersonList();
+    }
+
+    private final UniqueTeamList teams;
+
+    /*
+     * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
+     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
+     *
+     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
+     *   among constructors.
+     */
+    {
+        teams = new UniqueTeamList();
     }
 
     public TeamBuilder() {}
@@ -93,6 +108,32 @@ public class TeamBuilder implements ReadOnlyTeamBuilder {
         persons.remove(key);
     }
 
+    //// team-level operations
+
+    /**
+     * Returns true if a person with the same identity as {@code person} exists in the address book.
+     */
+    public boolean hasTeam(Team team) {
+        requireNonNull(team);
+        return teams.contains(team);
+    }
+
+    /**
+     * Adds a person to the address book.
+     * The person must not already exist in the address book.
+     */
+    public void addTeam(Team team) {
+        teams.add(team);
+    }
+
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeTeam(Team key) {
+        teams.remove(key);
+    }
+
     //// util methods
 
     @Override
@@ -104,6 +145,11 @@ public class TeamBuilder implements ReadOnlyTeamBuilder {
     @Override
     public ObservableList<Person> getPersonList() {
         return persons.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableList<Team> getTeamList() {
+        return teams.asUnmodifiableObservableList();
     }
 
     @Override

--- a/src/main/java/teambuilder/model/TeamBuilder.java
+++ b/src/main/java/teambuilder/model/TeamBuilder.java
@@ -111,7 +111,7 @@ public class TeamBuilder implements ReadOnlyTeamBuilder {
     //// team-level operations
 
     /**
-     * Returns true if a person with the same identity as {@code person} exists in the address book.
+     * Returns true if a team with the same identity as {@code team} exists in the address book.
      */
     public boolean hasTeam(Team team) {
         requireNonNull(team);
@@ -119,7 +119,7 @@ public class TeamBuilder implements ReadOnlyTeamBuilder {
     }
 
     /**
-     * Adds a person to the address book.
+     * Adds a team to the address book.
      * The person must not already exist in the address book.
      */
     public void addTeam(Team team) {
@@ -132,6 +132,14 @@ public class TeamBuilder implements ReadOnlyTeamBuilder {
      */
     public void removeTeam(Team key) {
         teams.remove(key);
+    }
+
+    public void updatePersonInTeams(Person person) {
+        teams.updatePersonInTeams(person);
+    }
+
+    public void removeFromAllTeams(Person person) {
+        teams.removeFromAllTeams(person);
     }
 
     //// util methods

--- a/src/main/java/teambuilder/model/person/Person.java
+++ b/src/main/java/teambuilder/model/person/Person.java
@@ -149,7 +149,7 @@ public class Person {
         Set<Tag> teams = getTeams();
         if (!teams.isEmpty()) {
             builder.append("; Teams: ");
-            tags.forEach(builder::append);
+            teams.forEach(builder::append);
         }
         return builder.toString();
     }

--- a/src/main/java/teambuilder/model/tag/Tag.java
+++ b/src/main/java/teambuilder/model/tag/Tag.java
@@ -33,6 +33,10 @@ public class Tag {
         return test.matches(VALIDATION_REGEX);
     }
 
+    public String getName() {
+        return tagName;
+    }
+
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object

--- a/src/main/java/teambuilder/model/team/Team.java
+++ b/src/main/java/teambuilder/model/team/Team.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.HashSet;
 import java.util.Set;
 
+import teambuilder.model.person.Person;
 import teambuilder.model.tag.Tag;
 
 /**
@@ -37,6 +38,22 @@ public class Team {
         this.skillTags.addAll(skillTags);
     }
 
+    public TeamName getName() {
+        return this.teamName;
+    }
+
+    /**
+     * Returns true if both teams have the same name.
+     * This defines a weaker notion of equality between two teams.
+     */
+    public boolean isSameTeam(Team otherTeam) {
+        if (otherTeam == this) {
+            return true;
+        }
+
+        return otherTeam != null
+                && otherTeam.getName().equals(getName());
+    }
 
     @Override
     public int hashCode() {

--- a/src/main/java/teambuilder/model/team/Team.java
+++ b/src/main/java/teambuilder/model/team/Team.java
@@ -6,7 +6,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import teambuilder.model.person.Name;
-import teambuilder.model.person.Person;
 import teambuilder.model.tag.Tag;
 
 /**

--- a/src/main/java/teambuilder/model/team/Team.java
+++ b/src/main/java/teambuilder/model/team/Team.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.HashSet;
 import java.util.Set;
 
+import teambuilder.model.person.Name;
 import teambuilder.model.person.Person;
 import teambuilder.model.tag.Tag;
 
@@ -21,7 +22,7 @@ public class Team {
     private final TeamName teamName;
     private final Desc teamDesc;
     private final Set<Tag> skillTags = new HashSet<>();
-    private final Set<String> members = new HashSet<>();
+    private final Set<Name> members = new HashSet<>();
 
 
     /**
@@ -53,6 +54,18 @@ public class Team {
 
         return otherTeam != null
                 && otherTeam.getName().equals(getName());
+    }
+
+    public void addPerson(Name name) {
+        members.add(name);
+    }
+
+    public void removePerson(Name name) {
+        members.remove(name);
+    }
+
+    public Set<Name> getMembers() {
+        return members;
     }
 
     @Override

--- a/src/main/java/teambuilder/model/team/UniqueTeamList.java
+++ b/src/main/java/teambuilder/model/team/UniqueTeamList.java
@@ -1,0 +1,75 @@
+package teambuilder.model.team;
+
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import teambuilder.model.person.Person;
+import teambuilder.model.person.exceptions.PersonNotFoundException;
+import teambuilder.model.team.exceptions.DuplicateTeamException;
+import teambuilder.model.team.exceptions.TeamNotFoundException;
+
+import java.util.Iterator;
+
+import static java.util.Objects.requireNonNull;
+
+public class UniqueTeamList implements Iterable<Team> {
+
+    private final ObservableList<Team> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Team> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent team as the given argument.
+     */
+    public boolean contains(Team toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameTeam);
+    }
+
+    /**
+     * Adds a team to the list.
+     * The team must not already exist in the list.
+     */
+    public void add(Team toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicateTeamException();
+        }
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Removes the equivalent team from the list.
+     * The team must exist in the list.
+     */
+    public void remove(Team toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new TeamNotFoundException();
+        }
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Team> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Team> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UniqueTeamList // instanceof handles nulls
+                && internalList.equals(((UniqueTeamList) other).internalList));
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+}

--- a/src/main/java/teambuilder/model/team/UniqueTeamList.java
+++ b/src/main/java/teambuilder/model/team/UniqueTeamList.java
@@ -1,5 +1,8 @@
 package teambuilder.model.team;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Iterator;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -8,11 +11,9 @@ import teambuilder.model.tag.Tag;
 import teambuilder.model.team.exceptions.DuplicateTeamException;
 import teambuilder.model.team.exceptions.TeamNotFoundException;
 
-import java.util.Iterator;
-import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
-
+/**
+ * A list of teams that enforces uniqueness between its elements and does not allow nulls.
+ */
 public class UniqueTeamList implements Iterable<Team> {
 
     private final ObservableList<Team> internalList = FXCollections.observableArrayList();
@@ -50,11 +51,13 @@ public class UniqueTeamList implements Iterable<Team> {
         }
     }
 
+    /**
+     * Add or delete person from TeamList depending on presence or absence of team tag respectively.
+     */
     public void updatePersonInTeams(Person person) {
         requireNonNull(person);
         Object[] allTeamTags = person.getTeams().toArray();
 
-        // Add or delete person from TeamList depending on presence or absence of team tag respectively
         for (Team team: internalList) {
             boolean isPresent = false;
             for (Object tag : allTeamTags) {
@@ -73,10 +76,12 @@ public class UniqueTeamList implements Iterable<Team> {
 
     }
 
+    /**
+     * delete person from all teams in TeamList.
+     */
     public void removeFromAllTeams(Person person) {
         requireNonNull(person);
 
-        // delete person from all teams in TeamList
         for (Team team: internalList) {
             team.removePerson(person.getName());
         }

--- a/src/main/java/teambuilder/model/team/UniqueTeamList.java
+++ b/src/main/java/teambuilder/model/team/UniqueTeamList.java
@@ -70,9 +70,6 @@ public class UniqueTeamList implements Iterable<Team> {
             }
         }
 
-        for (Team team: internalList) {
-            System.out.println(team.getMembers());
-        }
 
     }
 

--- a/src/main/java/teambuilder/model/team/UniqueTeamList.java
+++ b/src/main/java/teambuilder/model/team/UniqueTeamList.java
@@ -4,11 +4,12 @@ package teambuilder.model.team;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import teambuilder.model.person.Person;
-import teambuilder.model.person.exceptions.PersonNotFoundException;
+import teambuilder.model.tag.Tag;
 import teambuilder.model.team.exceptions.DuplicateTeamException;
 import teambuilder.model.team.exceptions.TeamNotFoundException;
 
 import java.util.Iterator;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -48,6 +49,43 @@ public class UniqueTeamList implements Iterable<Team> {
             throw new TeamNotFoundException();
         }
     }
+
+    public void updatePersonInTeams(Person person) {
+        requireNonNull(person);
+        Object[] allTeamTags = person.getTeams().toArray();
+
+        // Add or delete person from TeamList depending on presence or absence of team tag respectively
+        for (Team team: internalList) {
+            boolean isPresent = false;
+            for (Object tag : allTeamTags) {
+                Tag castedTag = (Tag) tag;
+                if (castedTag.getName().equals(team.toString())) {
+                    team.addPerson(person.getName());
+                    isPresent = true;
+                    break;
+                }
+            }
+            if (!isPresent) {
+                team.removePerson(person.getName());
+            }
+        }
+
+        for (Team team: internalList) {
+            System.out.println(team.getMembers());
+        }
+
+    }
+
+    public void removeFromAllTeams(Person person) {
+        requireNonNull(person);
+
+        // delete person from all teams in TeamList
+        for (Team team: internalList) {
+            team.removePerson(person.getName());
+        }
+
+    }
+
 
     /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.

--- a/src/main/java/teambuilder/model/team/exceptions/DuplicateTeamException.java
+++ b/src/main/java/teambuilder/model/team/exceptions/DuplicateTeamException.java
@@ -1,0 +1,11 @@
+package teambuilder.model.team.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Teams (Teams are considered duplicates if they have the same
+ * name).
+ */
+public class DuplicateTeamException extends RuntimeException {
+    public DuplicateTeamException() {
+        super("Operation would result in duplicate teams");
+    }
+}

--- a/src/main/java/teambuilder/model/team/exceptions/TeamNotFoundException.java
+++ b/src/main/java/teambuilder/model/team/exceptions/TeamNotFoundException.java
@@ -1,0 +1,6 @@
+package teambuilder.model.team.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified team.
+ */
+public class TeamNotFoundException extends RuntimeException {}

--- a/src/main/java/teambuilder/model/util/SampleDataUtil.java
+++ b/src/main/java/teambuilder/model/util/SampleDataUtil.java
@@ -22,22 +22,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), Phone.of("87438807"), Email.of("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), new Major("Computer Science"),
-                getTagSet("friends"), getTagSet("Team A")),
+                getTagSet("friends"), getTagSet()),
             new Person(new Name("Bernice Yu"), Phone.of("99272758"), Email.of("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Major("Computer Science"),
-                getTagSet("colleagues", "friends"), getTagSet("Team A", "CS2103T G17")),
+                getTagSet("colleagues", "friends"), getTagSet()),
             new Person(new Name("Charlotte Oliveiro"), Phone.of("93210283"), Email.of("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Major("Computer Science"),
-                getTagSet("neighbours"), getTagSet("Rh Rockers")),
+                getTagSet("neighbours"), getTagSet()),
             new Person(new Name("David Li"), Phone.of("91031282"), Email.of("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Major("Computer Science"),
-                getTagSet("family"), getTagSet("Club penguin")),
+                getTagSet("family"), getTagSet()),
             new Person(new Name("Irfan Ibrahim"), Phone.of("92492021"), Email.of("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), new Major("Computer Science"),
-                getTagSet("classmates"), getTagSet("RuneScapers")),
+                getTagSet("classmates"), getTagSet()),
             new Person(new Name("Roy Balakrishnan"), Phone.of("92624417"), Email.of("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), new Major("Computer Science"),
-                getTagSet("colleagues"), getTagSet("Coding is fun club"))
+                getTagSet("colleagues"), getTagSet())
         };
     }
 

--- a/src/test/java/teambuilder/logic/commands/AddCommandTest.java
+++ b/src/test/java/teambuilder/logic/commands/AddCommandTest.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.function.Predicate;
 
+import javafx.collections.FXCollections;
+import javafx.collections.transformation.FilteredList;
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
@@ -173,7 +175,7 @@ public class AddCommandTest {
 
         @Override
         public void updatePersonInTeams(Person person) {
-            throw new AssertionError("This method should not be called.");
+            return;
         }
 
         @Override
@@ -188,7 +190,7 @@ public class AddCommandTest {
 
         @Override
         public ObservableList<Team> getTeamList() {
-            throw new AssertionError("This method should not be called.");
+            return new FilteredList<>(FXCollections.unmodifiableObservableList(FXCollections.observableArrayList()));
         }
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {

--- a/src/test/java/teambuilder/logic/commands/AddCommandTest.java
+++ b/src/test/java/teambuilder/logic/commands/AddCommandTest.java
@@ -12,11 +12,11 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.function.Predicate;
 
-import javafx.collections.FXCollections;
-import javafx.collections.transformation.FilteredList;
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
 import teambuilder.commons.core.GuiSettings;
 import teambuilder.commons.core.Memento;
 import teambuilder.logic.commands.exceptions.CommandException;

--- a/src/test/java/teambuilder/logic/commands/AddCommandTest.java
+++ b/src/test/java/teambuilder/logic/commands/AddCommandTest.java
@@ -23,6 +23,7 @@ import teambuilder.model.ReadOnlyTeamBuilder;
 import teambuilder.model.ReadOnlyUserPrefs;
 import teambuilder.model.TeamBuilder;
 import teambuilder.model.person.Person;
+import teambuilder.model.team.Team;
 import teambuilder.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -156,10 +157,39 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasTeam(Team team) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteTeam(Team target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addTeam(Team team) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updatePersonInTeams(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void removeFromAllTeams(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getSortedPersonList() {
             throw new AssertionError("This method should not be called.");
         }
 
+        @Override
+        public ObservableList<Team> getTeamList() {
+            throw new AssertionError("This method should not be called.");
+        }
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/teambuilder/logic/commands/RedoCommandIntegrationTest.java
+++ b/src/test/java/teambuilder/logic/commands/RedoCommandIntegrationTest.java
@@ -19,6 +19,7 @@ import teambuilder.model.Model;
 import teambuilder.model.ReadOnlyTeamBuilder;
 import teambuilder.model.ReadOnlyUserPrefs;
 import teambuilder.model.person.Person;
+import teambuilder.model.team.Team;
 
 public class RedoCommandIntegrationTest {
     @Test
@@ -165,6 +166,31 @@ public class RedoCommandIntegrationTest {
         }
 
         @Override
+        public boolean hasTeam(Team team) {
+            throw new UnsupportedOperationException("Unimplemented method 'hasTeam'");
+        }
+
+        @Override
+        public void deleteTeam(Team target) {
+            throw new UnsupportedOperationException("Unimplemented method 'deleteTeam'");
+        }
+
+        @Override
+        public void addTeam(Team team) {
+            throw new UnsupportedOperationException("Unimplemented method 'addTeam'");
+        }
+
+        @Override
+        public void updatePersonInTeams(Person person) {
+            throw new UnsupportedOperationException("Unimplemented method 'updatePersonInTeams'");
+        }
+
+        @Override
+        public void removeFromAllTeams(Person person) {
+            throw new UnsupportedOperationException("Unimplemented method 'removeFromAllTeams'");
+        }
+
+        @Override
         public ObservableList<Person> getSortedPersonList() {
 
             throw new UnsupportedOperationException("Unimplemented method 'getSortedPersonList'");
@@ -179,6 +205,11 @@ public class RedoCommandIntegrationTest {
         @Override
         public void updateSort(Comparator<Person> comparator) {
             throw new UnsupportedOperationException("Unimplemented method 'updateSort'");
+        }
+
+        @Override
+        public ObservableList<Team> getTeamList() {
+            throw new AssertionError("This method should not be called.");
         }
 
     }

--- a/src/test/java/teambuilder/logic/commands/UndoCommandTest.java
+++ b/src/test/java/teambuilder/logic/commands/UndoCommandTest.java
@@ -19,6 +19,7 @@ import teambuilder.model.Model;
 import teambuilder.model.ReadOnlyTeamBuilder;
 import teambuilder.model.ReadOnlyUserPrefs;
 import teambuilder.model.person.Person;
+import teambuilder.model.team.Team;
 
 public class UndoCommandTest {
     @Test
@@ -173,6 +174,31 @@ public class UndoCommandTest {
         }
 
         @Override
+        public boolean hasTeam(Team team) {
+            throw new AssertionError("Unimplemented method 'hasTeam'");
+        }
+
+        @Override
+        public void deleteTeam(Team target) {
+            throw new AssertionError("Unimplemented method 'deleteTeam'");
+        }
+
+        @Override
+        public void addTeam(Team team) {
+            throw new AssertionError("Unimplemented method 'addTeam'");
+        }
+
+        @Override
+        public void updatePersonInTeams(Person person) {
+            throw new AssertionError("Unimplemented method 'updatePersonInTeams'");
+        }
+
+        @Override
+        public void removeFromAllTeams(Person person) {
+            throw new AssertionError("Unimplemented method 'removeFromAllTeams'");
+        }
+
+        @Override
         public ObservableList<Person> getSortedPersonList() {
 
             throw new UnsupportedOperationException("Unimplemented method 'getSortedPersonList'");
@@ -180,13 +206,17 @@ public class UndoCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
-
             throw new UnsupportedOperationException("Unimplemented method 'updateFilteredPersonList'");
         }
 
         @Override
         public void updateSort(Comparator<Person> comparator) {
             throw new UnsupportedOperationException("Unimplemented method 'updateSort'");
+        }
+
+        @Override
+        public ObservableList<Team> getTeamList() {
+            throw new AssertionError("Unimplemented method 'getTeamList'");
         }
 
     }

--- a/src/test/java/teambuilder/model/TeamBuilderTest.java
+++ b/src/test/java/teambuilder/model/TeamBuilderTest.java
@@ -20,6 +20,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import teambuilder.model.person.Person;
 import teambuilder.model.person.exceptions.DuplicatePersonException;
+import teambuilder.model.team.Team;
 import teambuilder.testutil.PersonBuilder;
 
 public class TeamBuilderTest {
@@ -96,6 +97,11 @@ public class TeamBuilderTest {
         @Override
         public ObservableList<Person> getPersonList() {
             return persons;
+        }
+
+        @Override
+        public ObservableList<Team> getTeamList() {
+            throw new AssertionError("This method should not be called.");
         }
     }
 

--- a/src/test/java/teambuilder/model/person/UniqueTeamListTest.java
+++ b/src/test/java/teambuilder/model/person/UniqueTeamListTest.java
@@ -1,13 +1,12 @@
 package teambuilder.model.person;
 
 import org.junit.jupiter.api.Test;
-import teambuilder.model.person.exceptions.DuplicatePersonException;
 import teambuilder.model.team.UniqueTeamList;
+import teambuilder.model.team.exceptions.DuplicateTeamException;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static teambuilder.testutil.Assert.assertThrows;
-import static teambuilder.testutil.TypicalPersons.ALICE;
 import static teambuilder.testutil.TypicalTeams.TEAM_A;
 
 public class UniqueTeamListTest {
@@ -38,7 +37,7 @@ public class UniqueTeamListTest {
     @Test
     public void add_duplicatePerson_throwsDuplicatePersonException() {
         uniqueTeamList.add(TEAM_A);
-        assertThrows(DuplicatePersonException.class, () -> uniqueTeamList.add(TEAM_A));
+        assertThrows(DuplicateTeamException.class, () -> uniqueTeamList.add(TEAM_A));
     }
 
 

--- a/src/test/java/teambuilder/model/person/UniqueTeamListTest.java
+++ b/src/test/java/teambuilder/model/person/UniqueTeamListTest.java
@@ -1,13 +1,14 @@
 package teambuilder.model.person;
 
-import org.junit.jupiter.api.Test;
-import teambuilder.model.team.UniqueTeamList;
-import teambuilder.model.team.exceptions.DuplicateTeamException;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static teambuilder.testutil.Assert.assertThrows;
 import static teambuilder.testutil.TypicalTeams.TEAM_A;
+
+import org.junit.jupiter.api.Test;
+
+import teambuilder.model.team.UniqueTeamList;
+import teambuilder.model.team.exceptions.DuplicateTeamException;
 
 public class UniqueTeamListTest {
 

--- a/src/test/java/teambuilder/model/person/UniqueTeamListTest.java
+++ b/src/test/java/teambuilder/model/person/UniqueTeamListTest.java
@@ -1,0 +1,45 @@
+package teambuilder.model.person;
+
+import org.junit.jupiter.api.Test;
+import teambuilder.model.person.exceptions.DuplicatePersonException;
+import teambuilder.model.team.UniqueTeamList;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static teambuilder.testutil.Assert.assertThrows;
+import static teambuilder.testutil.TypicalPersons.ALICE;
+import static teambuilder.testutil.TypicalTeams.TEAM_A;
+
+public class UniqueTeamListTest {
+
+    private final UniqueTeamList uniqueTeamList = new UniqueTeamList();
+
+    @Test
+    public void contains_nullTeam_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueTeamList.contains(null));
+    }
+
+    @Test
+    public void contains_personNotInList_returnsFalse() {
+        assertFalse(uniqueTeamList.contains(TEAM_A));
+    }
+
+    @Test
+    public void contains_personInList_returnsTrue() {
+        uniqueTeamList.add(TEAM_A);
+        assertTrue(uniqueTeamList.contains(TEAM_A));
+    }
+
+    @Test
+    public void add_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueTeamList.add(null));
+    }
+
+    @Test
+    public void add_duplicatePerson_throwsDuplicatePersonException() {
+        uniqueTeamList.add(TEAM_A);
+        assertThrows(DuplicatePersonException.class, () -> uniqueTeamList.add(TEAM_A));
+    }
+
+
+}

--- a/src/test/java/teambuilder/testutil/TypicalTeams.java
+++ b/src/test/java/teambuilder/testutil/TypicalTeams.java
@@ -1,0 +1,15 @@
+package teambuilder.testutil;
+
+import teambuilder.model.person.Person;
+import teambuilder.model.tag.Tag;
+import teambuilder.model.team.Desc;
+import teambuilder.model.team.Team;
+import teambuilder.model.team.TeamName;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+public class TypicalTeams {
+    public static final Team TEAM_A = new Team(new TeamName("Team A"), new Desc("This is Team A"),
+            new HashSet<Tag>(Arrays.asList(new Tag("Python"), new Tag("ReactNative"))));
+}

--- a/src/test/java/teambuilder/testutil/TypicalTeams.java
+++ b/src/test/java/teambuilder/testutil/TypicalTeams.java
@@ -1,14 +1,16 @@
 package teambuilder.testutil;
 
-import teambuilder.model.person.Person;
+import java.util.Arrays;
+import java.util.HashSet;
+
 import teambuilder.model.tag.Tag;
 import teambuilder.model.team.Desc;
 import teambuilder.model.team.Team;
 import teambuilder.model.team.TeamName;
 
-import java.util.Arrays;
-import java.util.HashSet;
-
+/**
+ * Sample teams for testing
+ */
 public class TypicalTeams {
     public static final Team TEAM_A = new Team(new TeamName("Team A"), new Desc("This is Team A"),
             new HashSet<Tag>(Arrays.asList(new Tag("Python"), new Tag("ReactNative"))));


### PR DESCRIPTION
Close #64 #75 #77 

## Implemented
- [X] TeamList class
  - Team description
  - Team name
  - Members (using Name object in hashset)
  - skill tags required for team (using Tag object in hashset)
- [X] Create team command
  - Creates a new team in teamlist, allowing persons to attach corresponding team tag
  - Team name and Team desc are required fields
  - Command: create tn/TEAMNAME td/TEAMDESC [t/TAG]...
  - e.g `create tn/team a td/This is a description. t/Python t/ReactNative` 
- [X] Remove team command
  - Removes team from teamlist
  - Command: remove TEAMNAME
  - e.g `remove team a` 
- [X] Edit/Delete person cascades to all teams
  - Will remove the person's Name object from all the teams  
- [X] Add/Edit person with Team tags only if teams created beforehand
