### PR TITLE
Add exception handling for sort command args

### DIFF
--- a/src/main/java/teambuilder/logic/parser/SortCommandParser.java
+++ b/src/main/java/teambuilder/logic/parser/SortCommandParser.java
@@ -23,10 +23,15 @@ public class SortCommandParser implements Parser<SortCommand> {
         }
 
         String[] argsArr = trimmedArgs.split("\\s+");
-        String order = argsArr[0].toLowerCase();
-        String sortBy = argsArr[1].toLowerCase();
+        if (argsArr.length != 2) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        } else {
+            String order = argsArr[0].toLowerCase();
+            String sortBy = argsArr[1].toLowerCase();
+            return new SortCommand(order, sortBy);
+        }
 
-        return new SortCommand(order, sortBy);
     }
 
 }


### PR DESCRIPTION
Close #127 #118 #113 

### Bug Reported:
No error message displayed if incorrect ORDER parameter used or missing SORT_BY parameter.

### Resolution:
Check strictly for presence of 2 arguments in `SortCommandParser`. Otherwise, throw exception for incorrect command format.