### PR TITLE
Remove 'listing all tags' subtitle from UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -445,10 +445,9 @@ This includes:
 1. Clearing all entries
 2. Undoing a command
 3. Redoing an undo command
-4. Listing all Tags
-5. Exiting the program
-6. Saving data
-7. Editing the data file
+4. Exiting the program
+5. Saving data
+6. Editing the data file
 
 ### Clearing all entries : `clear`
 


### PR DESCRIPTION
Close #139 

### Bug Reported:
Extra feature(listing all tags) that has not been implemented is found in UG.

### Resolution:
Remove the subtitle of this feature from UG.