### PR TITLE
Add note for add command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -221,6 +221,10 @@ Let's add his contacts to Team Builder as a new potential teammate for future ev
 
 **Result**: **Image**
 
+<div markdown="block" class="alert alert-info">
+:information_source: **Note:**
+The order of persons added in the list may not be in chronological order.
+</div>
 
 ### Listing all contacts : `list`
 


### PR DESCRIPTION
Close #128 

### Bug Reported:
Person added using the Add Command are not in chronological order.

### Resolution:
Add clarifying note in UG to specify that the Add Command may not add persons in chronological order.