### PR TITLE
Fix error message for Invalid index

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -571,8 +571,13 @@ These are features that will improve your experience using TeamBuilder, to be ad
 
 ## Support for long tags
 Currently, whether it is a skill tag or a team tag, TeamBuilder will try to display the whole tag regardless of how long it is, causing it to overflow out of the window and be un-readable.
-In the future,
+Future changes:
 - Tags that exceed a character count of 20 characters will be truncated and have a "..." after it.
 - Users will be able to view the full tag by hovering their cursor over the tag.
-  - This will not change the behaviour of the `add`, `edit`, or `find` commands.
+- This will not change the behaviour of the `add`, `edit`, or `find` commands.
+
+## Phone number limit 
+Currently, there is no limit to the length of a contacts phone number.
+Future changes:
+- Phone number will have a maximum length of 15 digits, as that is the longest viable phone number.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -100,6 +100,7 @@ Below is the full table of contents, in case you are looking for something very 
   - [Saving the data](#saving-the-data)
   - [Editing the data file](#editing-the-data-file)
 - [FAQ](#faq)
+- [**Coming soon!:** Future Features](#future-features)
 
 </div>
 
@@ -565,5 +566,13 @@ If your changes to the data file makes its format invalid, TeamBuilder will disc
 **A**: You might have input an invalid command. Either the command word doesn't exist or the parameters entered are invalid.
 
 --------------------------------------------------------------------------------------------------------------------
+# Future features
+These are features that will improve your experience using TeamBuilder, to be added in the future. Look forward to them!
 
+## Support for long tags
+Currently, whether it is a skill tag or a team tag, TeamBuilder will try to display the whole tag regardless of how long it is, causing it to overflow out of the window and be un-readable.
+In the future,
+- Tags that exceed a character count of 20 characters will be truncated and have a "..." after it.
+- Users will be able to view the full tag by hovering their cursor over the tag.
+  - This will not change the behaviour of the `add`, `edit`, or `find` commands.
 

--- a/src/main/java/teambuilder/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/teambuilder/logic/parser/DeleteCommandParser.java
@@ -22,7 +22,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             return new DeleteCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(pe.getMessage() + "\n" + MESSAGE_INVALID_COMMAND_FORMAT,
+                            DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/teambuilder/logic/parser/EditCommandParser.java
+++ b/src/main/java/teambuilder/logic/parser/EditCommandParser.java
@@ -42,7 +42,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(pe.getMessage() + "\n"
+                    + MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();

--- a/src/test/java/teambuilder/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/teambuilder/logic/parser/DeleteCommandParserTest.java
@@ -27,6 +27,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(ParserUtil.MESSAGE_INVALID_INDEX + "\n"
+                + MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/teambuilder/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/teambuilder/logic/parser/EditCommandParserTest.java
@@ -46,7 +46,8 @@ public class EditCommandParserTest {
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+            String.format(ParserUtil.MESSAGE_INVALID_INDEX + "\n"
+                    + MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
 
     private EditCommandParser parser = new EditCommandParser();
 


### PR DESCRIPTION
#124 
Although both EditCommandParser and DeleteCommandParser are able to detect invalid indexes, both do not show the error message indicating an invalid index is given by the user. Rather, they only give the correct command format. 

To fix this, simply added the invalid index error message one line before the Invalid command message. This works as an invalid index is also a subset of the invalid command (technically), so it makes sense to show both.

