### PR TITLE
Fix Ui to prevent clipping of TeamList

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="Team Builder App" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="600" minWidth="680" onCloseRequest="#handleExit" title="Team Builder App" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/team_builder_icon.png" />
   </icons>


### PR DESCRIPTION
Clipping occurs as both the teamList panel and personList panel have reached their minimum width and cannot grow smaller, yet the mainWindow's minimum width is small than the sum of the two panel's min width. 

The simple fix is to restrict the minimum width of the main window to be the sum of the minimum width of the two panels.